### PR TITLE
removed strtolower() and trim() on site name check

### DIFF
--- a/public_html/api.php
+++ b/public_html/api.php
@@ -217,7 +217,7 @@ if ( $action == 'import' ) {
 } else if ( $action == 'run_single_command' ) {
 
 	validate_origin();
-	$site = strtolower ( trim ( get_request ( 'site' , '' ) ) ) ;
+	$site = get_request ( 'site' , '' ) ;
 	if ( !$qs->setSite ( $site ) ) {
 		$out['status'] = "Error while setting site '{$site}': " . $qs->last_error_message ;
 	} else {


### PR DESCRIPTION
within run_single_command, the site name is checked against the currently available sites. This was done, using the functions strtolower() and trim() to clean up the file name. The only problem is that at no other point in the app are the site names adjusted this way, causing issues, when the site name uses upper case letters or spaces in the beginning and end. 
In wmde/wikibase-release-pipeline#293 I suggested using the same variable to full the site name, as the label, go show to the user which wikibase instance the user is going to write to with the current quickstatement page. For this branding however, users might be inclined to use a name that contains capital letters causing Quickstatements to fail when writing to the API.